### PR TITLE
Add user config and quote envs rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ If you have any requirements or dependencies, add a section describing those and
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-This extension contributes the following settings:
-
-* `myExtension.enable`: Enable/disable this extension.
+To change the settings of this extension create a config file inside your .buildkite folder.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
-# buildkite-parse README
+# Buildkite Parse
 
-BuildkiteParse is a simple vscode extension that provides additional syntax highlighting to features specific to buildkite pipeline.yml files that cannot be provided by simple json schemas.
+BuildkiteParse is a simple vscode extension that provides additional syntax highlighting to features specific
+to buildkite pipeline.yml files that cannot be provided by simple json schemas.
 
 ## Features
 
 Current features include the following:
 
-1. Syntax highlighting for incorrectly used environment variables
-2. Depends_on step highlighting
+1. Syntax highlighting for incorrectly used environment variables - mispelt or missing environment variables are highlighted
+2. Depends_on step highlighting - ensures each step in your pipeline with a depends_on is used earlier in the pipeline
+3. No quoted environment variables - ensures environment vars are not accidentally quoted
 
-## Requirements
+## Configuration
 
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+To configure the extension create a file called `bkparse.config.json` in your .buildkite directory.
+This file has type hinting for a better dx.
 
-## Extension Settings
+```
+{
+  "rules": {
+    "DependsOnRule": false,
+    "EnvironmentVarRule": false,
+    "NoQuotedEnvRule": true
+  },
+  "excludedEnvs": ["CI", "PATH", "GLOBAL_TF_BACKEND_S3_REGION"]
+}
+```
 
-To change the settings of this extension create a config file inside your .buildkite folder.
+ExcludedEnvs should be environment variables that you may be injecting from outside the pipeline. Add them to this array to exempt them from the `EnvironmentVarRule`.
+
 
 ## Known Issues
 
-1. Depends_on parsing is a little broken at the moment
+None right now, create an issue if you find anything!
 
-## Release Notes
+# Release Notes
 
-Users appreciate release notes as you update your extension.
+## 0.0.4
 
-###
+* Added new rule allowing the user to check environment variables for quotes that would be included in the string.
+
+Eg: It will provide a warning for the following: `REALLY_COOL_ENVIRONMENT: "super-cool-environment"` as the double quotes will end up included in the string.
+This often happens when someone copy pastes the variable from another environment which will parse the quoting as expected.
+It can be turned on and off in your config file with the value `NoQuotedEnvRule: boolean`
+
+* Added a config file
+
+This config file can be added to your .buildkite directory to turn specific rules on and off, as well as add in external environment variables that may be injected from outside your pipeline.
 
 ---
 
@@ -43,17 +64,6 @@ Or you can throw a buildkite pipeline in there to have a play with.
 
 Below are the current features in development
 
-1. Settings for environment variables allowing the user to provide vars that are inserted externally to the pipeline.yml file itself.
-
-## Following extension guidelines
-
-Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
-
-* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
-
-## Other info
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**
+* Allow parsing of bash scripts that generate pipeline files
+* Add tests for all rules
+* Npm install it as a package instead

--- a/package.json
+++ b/package.json
@@ -28,7 +28,13 @@
     "commands": [
       {
         "command": "buildkite-parse.helloWorld",
-        "title": "Fix Buildkite Pipeline"
+        "title": "Buildkite Parser Active"
+      }
+    ],
+    "jsonValidation": [
+      {
+        "fileMatch": ["bkparse.config.json"],
+        "url": "./src/schemas/bkparse.config.schema.json"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,18 +8,49 @@ export function activate(context: vscode.ExtensionContext) {
 
   const parser = new DocumentParser();
 
-  const parse = (document: vscode.TextDocument) => {
+  const parseDoc = (document: vscode.TextDocument) => {
     if (!/(buildkite|pipeline).*\.ya?ml$/.test(document.fileName)) {
       diagnosticCollection.delete(document.uri);
       return;
     }
+    diagnosticCollection.delete(document.uri);
     const diagnostics = parser.parse(document);
     diagnosticCollection.set(document.uri, diagnostics);
   };
 
-  vscode.workspace.textDocuments.forEach(parse);
-  vscode.workspace.onDidOpenTextDocument(parse);
-  vscode.workspace.onDidChangeTextDocument(e => parse(e.document));
+  vscode.workspace.textDocuments.forEach(parseDoc);
+  vscode.workspace.onDidOpenTextDocument(parseDoc);
+  vscode.workspace.onDidChangeTextDocument(e => parseDoc(e.document));
+
+  // below is how we interact with the users config file
+  // we don't want to load the file from disk every single time we parse
+  // so instead we throw it in memory. And then re pull it if we ever see a change to
+  // the users config file.
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    const root = folders[0];
+    const pattern = new vscode.RelativePattern(root, '.buildkite/bkparse.config.json');
+    const configWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+
+    context.subscriptions.push(
+      configWatcher,
+      configWatcher.onDidChange(() => {
+        console.log('Config file changed, reloading...');
+        parser.reloadConfig();
+        vscode.workspace.textDocuments.forEach(parseDoc);
+      }),
+      configWatcher.onDidCreate(() => {
+        console.log('Config file created, loading...');
+        parser.reloadConfig();
+        vscode.workspace.textDocuments.forEach(parseDoc);
+      }),
+      configWatcher.onDidDelete(() => {
+        console.log('Config file deleted, resetting to defaults...');
+        parser.reloadConfig();
+        vscode.workspace.textDocuments.forEach(parseDoc);
+      })
+    );
+  }
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,17 +35,14 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
       configWatcher,
       configWatcher.onDidChange(() => {
-        console.log('Config file changed, reloading...');
         parser.reloadConfig();
         vscode.workspace.textDocuments.forEach(parseDoc);
       }),
       configWatcher.onDidCreate(() => {
-        console.log('Config file created, loading...');
         parser.reloadConfig();
         vscode.workspace.textDocuments.forEach(parseDoc);
       }),
       configWatcher.onDidDelete(() => {
-        console.log('Config file deleted, resetting to defaults...');
         parser.reloadConfig();
         vscode.workspace.textDocuments.forEach(parseDoc);
       })

--- a/src/parser/DocumentParser.ts
+++ b/src/parser/DocumentParser.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import { NoQuotedEnvRule } from '../rules/NoQuotedEnvRule';
 
-interface ParserConfig {
+export interface ParserConfig {
   rules?: Record<string, any>;
   excludedEnvs?: string[];
 }
@@ -47,7 +47,7 @@ export class DocumentParser {
       .filter(ruleConstructor => localConfig.rules?.[ruleConstructor.name] !== false)
       .map(ruleConstructor => new ruleConstructor(localConfig.excludedEnvs || []));
 
-    rules.forEach(rule => rule.initialize(document));
+    rules.forEach(rule => rule.initialize(document, localConfig));
 
     const lines = document.getText().split(/\r?\n/);
     lines.forEach((line, index) => {

--- a/src/parser/DocumentParser.ts
+++ b/src/parser/DocumentParser.ts
@@ -47,7 +47,6 @@ export class DocumentParser {
       .filter(ruleConstructor => localConfig.rules?.[ruleConstructor.name] !== false)
       .map(ruleConstructor => new ruleConstructor(localConfig.excludedEnvs || []));
 
-    console.log('Active rules:', rules.map(rule => rule.constructor.name));
     rules.forEach(rule => rule.initialize(document));
 
     const lines = document.getText().split(/\r?\n/);
@@ -55,9 +54,7 @@ export class DocumentParser {
       rules.forEach(rule => rule.processLine(line, index));
     });
 
-    const diagnostics = rules.flatMap(rule => rule.finalize());
-    console.log('Diagnostics:', diagnostics.length);
-    return diagnostics;
+    return rules.flatMap(rule => rule.finalize());
   }
 
   private loadConfig(): Partial<ParserConfig> {

--- a/src/parser/DocumentParser.ts
+++ b/src/parser/DocumentParser.ts
@@ -12,18 +12,7 @@ interface ParserConfig {
 }
 
 export class DocumentParser {
-  private rules: Rule[] = [];
   private config: ParserConfig = {};
-
-  constructor() {
-    this.rules = [
-      new DependsOnRule(),
-      new EnvironmentVarRule(),
-      new NoQuotedEnvRule(),
-    ];
-
-    this.reloadConfig();
-  }
 
   public reloadConfig(): void {
     const userConfig = this.loadConfig();
@@ -63,10 +52,10 @@ export class DocumentParser {
 
     const lines = document.getText().split(/\r?\n/);
     lines.forEach((line, index) => {
-      this.rules.forEach(rule => rule.processLine(line, index));
+      rules.forEach(rule => rule.processLine(line, index));
     });
 
-    const diagnostics = this.rules.flatMap(rule => rule.finalize());
+    const diagnostics = rules.flatMap(rule => rule.finalize());
     console.log('Diagnostics:', diagnostics.length);
     return diagnostics;
   }

--- a/src/parser/DocumentParser.ts
+++ b/src/parser/DocumentParser.ts
@@ -2,26 +2,124 @@ import * as vscode from 'vscode';
 import { Rule } from '../types/rule';
 import { DependsOnRule } from '../rules/DependsOnRule';
 import { EnvironmentVarRule } from '../rules/EnvironmentVarRule';
+import path from 'path';
+import fs from 'fs';
+import { NoQuotedEnvRule } from '../rules/NoQuotedEnvRule';
+
+interface ParserConfig {
+  rules?: Record<string, any>;
+  excludedEnvs?: string[];
+}
 
 export class DocumentParser {
   private rules: Rule[] = [];
+  private config: ParserConfig = {};
 
   constructor() {
     this.rules = [
       new DependsOnRule(),
       new EnvironmentVarRule(),
-      // new KeyCheckRule(),
+      new NoQuotedEnvRule(),
     ];
+
+    this.reloadConfig();
+  }
+
+  public reloadConfig(): void {
+    const userConfig = this.loadConfig();
+    const defaults = this.defaultConfig();
+    this.config = {
+      rules: { ...defaults.rules, ...userConfig.rules },
+      excludedEnvs: userConfig.excludedEnvs || [],
+    };
+  }
+
+  private defaultConfig(): ParserConfig {
+    return {
+      rules: {
+        DependsOnRule: true,
+        EnvironmentVarRule: true,
+        NoQuotedEnvRule: true,
+      },
+      excludedEnvs: [],
+    };
   }
 
   parse(document: vscode.TextDocument): vscode.Diagnostic[] {
-    this.rules.forEach(rule => rule.initialize(document));
+    const localConfig = this.config;
+
+    const ruleConstructors: Array<new (excludedEnvs?: string[]) => Rule> = [
+      DependsOnRule,
+      EnvironmentVarRule,
+      NoQuotedEnvRule
+    ];
+
+    const rules = ruleConstructors
+      .filter(ruleConstructor => localConfig.rules?.[ruleConstructor.name] !== false)
+      .map(ruleConstructor => new ruleConstructor(localConfig.excludedEnvs || []));
+
+    console.log('Active rules:', rules.map(rule => rule.constructor.name));
+    rules.forEach(rule => rule.initialize(document));
 
     const lines = document.getText().split(/\r?\n/);
     lines.forEach((line, index) => {
       this.rules.forEach(rule => rule.processLine(line, index));
     });
 
-    return this.rules.flatMap(rule => rule.finalize());
+    const diagnostics = this.rules.flatMap(rule => rule.finalize());
+    console.log('Diagnostics:', diagnostics.length);
+    return diagnostics;
+  }
+
+  private loadConfig(): Partial<ParserConfig> {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders?.length) {
+      return {};
+    }
+
+    const root = folders[0].uri.fsPath;
+    const configPath = path.join(root, '.buildkite', 'bkparse.config.json');
+    if (!fs.existsSync(configPath)) {
+      return {};
+    }
+
+    try {
+      const raw = fs.readFileSync(configPath, 'utf8');
+      const parsed = JSON.parse(raw);
+
+      const allowedRoot = new Set(['rules', 'excludedEnvs']);
+      for (const key of Object.keys(parsed)) {
+        if (!allowedRoot.has(key)) {
+          throw new Error(`Unknown property "${key}" in bkparse.config.json`);
+        }
+      }
+
+      const allowedRules = new Set([
+        'DependsOnRule',
+        'EnvironmentVarRule',
+        'NoQuotedEnvRule'
+      ]);
+
+      if (parsed.rules) {
+        for (const r of Object.keys(parsed.rules)) {
+          if (!allowedRules.has(r)) {
+            throw new Error(`Unknown rule "${r}" in bkparse.config.json.rules`);
+          }
+        }
+      }
+
+      if (parsed.excludedEnvs && !Array.isArray(parsed.excludedEnvs)) {
+        throw new Error(`"excludedEnvs" must be an array in bkparse.config.json`);
+      }
+
+      return {
+        rules: parsed.rules,
+        excludedEnvs: parsed.excludedEnvs,
+      };
+    } catch (err: unknown) {
+      const message = (err && typeof err === 'object' && 'message' in err) ? (err as any).message : err;
+      console.error('Failed loading config:', message);
+      return {};
+    }
   }
 }

--- a/src/rules/DependsOnRule.ts
+++ b/src/rules/DependsOnRule.ts
@@ -17,7 +17,6 @@ export class DependsOnRule implements Rule {
   private dependsOnRefs: DependsOnReference[] = [];
 
   initialize(): void {
-    console.log('DependsOnRule initialized', this.definedKeys.length);
     this.definedKeys = [];
     this.dependsOnRefs = [];
   }

--- a/src/rules/DependsOnRule.ts
+++ b/src/rules/DependsOnRule.ts
@@ -17,6 +17,7 @@ export class DependsOnRule implements Rule {
   private dependsOnRefs: DependsOnReference[] = [];
 
   initialize(): void {
+    console.log('DependsOnRule initialized', this.definedKeys.length);
     this.definedKeys = [];
     this.dependsOnRefs = [];
   }
@@ -72,6 +73,8 @@ export class DependsOnRule implements Rule {
       }
     }
 
+    this.definedKeys = [];
+    this.dependsOnRefs = [];
     return diagnostics;
   }
 }

--- a/src/rules/EnvironmentVarRule.ts
+++ b/src/rules/EnvironmentVarRule.ts
@@ -1,13 +1,14 @@
 import * as vscode from 'vscode';
 import { Rule } from '../types/rule';
+import { ParserConfig } from '../parser/DocumentParser';
 
 export class EnvironmentVarRule implements Rule {
   private definedEnvVars: Set<string> = new Set();
   private usedEnvVars: { name: string, range: vscode.Range }[] = [];
   private inEnvSection = false;
 
-  initialize(): void {
-    this.definedEnvVars.clear();
+  initialize(_document: vscode.TextDocument, config: ParserConfig): void {
+    this.definedEnvVars = new Set(config.excludedEnvs || []);
     this.usedEnvVars = [];
     this.inEnvSection = false;
   }

--- a/src/rules/EnvironmentVarRule.ts
+++ b/src/rules/EnvironmentVarRule.ts
@@ -46,7 +46,6 @@ export class EnvironmentVarRule implements Rule {
 
   finalize(): vscode.Diagnostic[] {
     const diagnostics: vscode.Diagnostic[] = [];
-
     for (const used of this.usedEnvVars) {
       if (!this.definedEnvVars.has(used.name)) {
         diagnostics.push(new vscode.Diagnostic(
@@ -56,7 +55,9 @@ export class EnvironmentVarRule implements Rule {
         ));
       }
     }
-
+    this.definedEnvVars.clear();
+    this.usedEnvVars = [];
+    this.inEnvSection = false;
     return diagnostics;
   }
 }

--- a/src/rules/EnvironmentVarRule.ts
+++ b/src/rules/EnvironmentVarRule.ts
@@ -55,6 +55,8 @@ export class EnvironmentVarRule implements Rule {
         ));
       }
     }
+    // TODO: Add flush function to each rule
+    // to clear the state after processing
     this.definedEnvVars.clear();
     this.usedEnvVars = [];
     this.inEnvSection = false;

--- a/src/rules/NoQuotedEnvRule.ts
+++ b/src/rules/NoQuotedEnvRule.ts
@@ -7,7 +7,6 @@ export class NoQuotedEnvRule implements Rule {
   private envIndent: number = 0;
 
   initialize(): void {
-    console.log('NoQuotedEnvRule initialized');
     this.violations = [];
     this.inEnvSection = false;
     this.envIndent = 0;

--- a/src/rules/NoQuotedEnvRule.ts
+++ b/src/rules/NoQuotedEnvRule.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import { Rule } from '../types/rule';
+
+export class NoQuotedEnvValueRule implements Rule {
+  private violations: { name: string; range: vscode.Range }[] = [];
+
+  initialize(): void {
+    this.violations = [];
+  }
+
+  processLine(line: string, lineNumber: number): void {
+    const regex = /(['"])([A-Z][A-Z0-9_]+)\1/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(line)) !== null) {
+      const fullMatch = match[0];
+      const varName = match[2];
+      const startCol = match.index;
+      const endCol = startCol + fullMatch.length;
+
+      this.violations.push({
+        name: varName,
+        range: new vscode.Range(
+          new vscode.Position(lineNumber, startCol),
+          new vscode.Position(lineNumber, endCol)
+        )
+      });
+    }
+  }
+
+  finalize(): vscode.Diagnostic[] {
+    return this.violations.map(v => new vscode.Diagnostic(
+      v.range,
+      `Environment variable "${v.name}" should not be quoted.`,
+      vscode.DiagnosticSeverity.Error
+    ));
+  }
+}

--- a/src/rules/NoQuotedEnvRule.ts
+++ b/src/rules/NoQuotedEnvRule.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 import { Rule } from '../types/rule';
 
-export class NoQuotedEnvValueRule implements Rule {
+export class NoQuotedEnvRule implements Rule {
   private violations: { name: string; range: vscode.Range }[] = [];
 
   initialize(): void {
+    console.log('NoQuotedEnvRule initialized');
     this.violations = [];
   }
 
@@ -29,10 +30,13 @@ export class NoQuotedEnvValueRule implements Rule {
   }
 
   finalize(): vscode.Diagnostic[] {
-    return this.violations.map(v => new vscode.Diagnostic(
+    const violations = this.violations.map(v => new vscode.Diagnostic(
       v.range,
       `Environment variable "${v.name}" should not be quoted.`,
       vscode.DiagnosticSeverity.Error
     ));
+
+    this.violations = [];
+    return violations;
   }
 }

--- a/src/rules/NoQuotedEnvRule.ts
+++ b/src/rules/NoQuotedEnvRule.ts
@@ -14,7 +14,6 @@ export class NoQuotedEnvRule implements Rule {
   }
 
   processLine(line: string, lineNumber: number): void {
-    // Detect start of env section
     const envHeaderMatch = /^([ \t]*)env:\s*$/.exec(line);
     if (envHeaderMatch) {
       this.inEnvSection = true;
@@ -23,19 +22,16 @@ export class NoQuotedEnvRule implements Rule {
     }
 
     if (this.inEnvSection) {
-      // Determine current line indentation
       const indentMatch = /^([ \t]*)/.exec(line);
       const currentIndent = indentMatch ? indentMatch[1].length : 0;
-      // Exit env section if outdented or new top-level key
+
       if (currentIndent <= this.envIndent || (/^\s*\S+\s*:\s*/.test(line) && indentMatch && indentMatch[1].length <= this.envIndent)) {
         this.inEnvSection = false;
       } else {
-        // Inside env entries: check key: value pattern
-        const kvMatch = /^\s*([A-Z][A-Z0-9_]*)\s*:\s*(.+?)\s*(?:#.*)?$/.exec(line);
-        if (kvMatch) {
-          const varName = kvMatch[1];
-          const rawValue = kvMatch[2].trim();
-          // Check if value is quoted
+        const keyValMatch = /^\s*([A-Z][A-Z0-9_]*)\s*:\s*(.+?)\s*(?:#.*)?$/.exec(line);
+        if (keyValMatch) {
+          const varName = keyValMatch[1];
+          const rawValue = keyValMatch[2].trim();
           const quoteMatch = /^(['"])(.*)\1$/.exec(rawValue);
           if (quoteMatch) {
             const startCol = line.indexOf(rawValue);

--- a/src/schemas/bkparse.config.json
+++ b/src/schemas/bkparse.config.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "DependsOnRule": true,
+    "EnvironmentVarRule": true,
+    "NoQuotedEnvRule": true
+  },
+  "excludedEnvs": ["CI", "PATH"]
+}

--- a/src/schemas/bkparse.config.schema.json
+++ b/src/schemas/bkparse.config.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Buildkite Parser Config",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "DependsOnRule":   { "type": "boolean" },
+        "EnvironmentVarRule": { "type": "boolean" },
+        "NoQuotedEnvRule": { "type": "boolean" }
+      }
+    },
+    "excludedEnvs": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,7 +1,23 @@
 import * as vscode from 'vscode';
 
 export interface Rule {
+  /**
+   * Initialize the rule, this is called once per parse, use this to set up any state that the rule needs
+   */
   initialize(document: vscode.TextDocument): void;
+
+  /**
+   * This is called once per line, use this to process the line and update the state of the rule
+   */
   processLine(line: string, lineNumber: number): void;
+
+  /**
+   * This is called once per parse at the end, use this to finalize the rule and return diagnostics
+   */
   finalize(): vscode.Diagnostic[];
+
+  /**
+   * TODO: This will be called once, to clean up state of the processor
+   */
+  // flush(): void;
 }

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
+import { ParserConfig } from '../parser/DocumentParser';
 
 export interface Rule {
   /**
    * Initialize the rule, this is called once per parse, use this to set up any state that the rule needs
    */
-  initialize(document: vscode.TextDocument): void;
+  initialize(document: vscode.TextDocument, config?: ParserConfig): void;
 
   /**
    * This is called once per line, use this to process the line and update the state of the rule

--- a/test-pipelines/.buildkite/bkparse.config.json
+++ b/test-pipelines/.buildkite/bkparse.config.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "DependsOnRule": true,
+    "EnvironmentVarRule": true,
+    "NoQuotedEnvRule": true
+  },
+  "excludedEnvs": ["CI", "PATH"]
+}

--- a/test-pipelines/.buildkite/buildkite-parse.config.ts
+++ b/test-pipelines/.buildkite/buildkite-parse.config.ts
@@ -1,7 +1,0 @@
-const GLOBAL_ENV_VARS = [
-
-];
-
-export const config = {
-  GLOBAL_ENV_VARS: ["GLOBAL_TF_BACKEND_S3_REGION"]
-};

--- a/test/.buildkite/bkparse.config.json
+++ b/test/.buildkite/bkparse.config.json
@@ -4,5 +4,5 @@
     "EnvironmentVarRule": true,
     "NoQuotedEnvRule": true
   },
-  "excludedEnvs": ["CI", "PATH"]
+  "excludedEnvs": ["CI", "PATH", "GLOBAL_TF_BACKEND_S3_REGION"]
 }

--- a/test/.buildkite/bkparse.config.json
+++ b/test/.buildkite/bkparse.config.json
@@ -2,7 +2,7 @@
   "rules": {
     "DependsOnRule": false,
     "EnvironmentVarRule": false,
-    "NoQuotedEnvRule": false
+    "NoQuotedEnvRule": true
   },
   "excludedEnvs": ["CI", "PATH", "GLOBAL_TF_BACKEND_S3_REGION"]
 }

--- a/test/.buildkite/bkparse.config.json
+++ b/test/.buildkite/bkparse.config.json
@@ -1,8 +1,8 @@
 {
   "rules": {
-    "DependsOnRule": true,
-    "EnvironmentVarRule": true,
-    "NoQuotedEnvRule": true
+    "DependsOnRule": false,
+    "EnvironmentVarRule": false,
+    "NoQuotedEnvRule": false
   },
   "excludedEnvs": ["CI", "PATH", "GLOBAL_TF_BACKEND_S3_REGION"]
 }

--- a/test/.buildkite/bkparse.config.json
+++ b/test/.buildkite/bkparse.config.json
@@ -1,8 +1,8 @@
 {
   "rules": {
-    "DependsOnRule": false,
-    "EnvironmentVarRule": false,
+    "DependsOnRule": true,
+    "EnvironmentVarRule": true,
     "NoQuotedEnvRule": true
   },
-  "excludedEnvs": ["CI", "PATH", "GLOBAL_TF_BACKEND_S3_REGION"]
+  "excludedEnvs": ["CI", "PATH", "BUILDKITE_S3_DEFAULT_REGIO"]
 }

--- a/test/.buildkite/pipeline.yml
+++ b/test/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 env:
   BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: s3://vivi-buildkite-artifacts/$BUILDKITE_JOB_ID
   BUILDKITE_S3_DEFAULT_REGION: ap-southeast-2
-  DELETE_DATABASE: vivi-primary
-  REALLY_COOL_ENVIRONMENT: super-cool-environment
+  DELETE_DATABASE: 'vivi-primary'
+  REALLY_COOL_ENVIRONMENT: "super-cool-environment"
 
 steps:
   - label: ':react: Test'
@@ -16,7 +16,7 @@ steps:
           build: build
           image-repository: ${BUILDKITE_S3_DEFAULT_REGION}/build-cache
           image-name: ${BUILDKITE_S3_DEFAULT_REGION}-build
-          cache-from: build:${BUILDKITE_S3_DEFAULT_REGION}/build-cache:${REALLY_COOL_ENVIRONMENT}-build
+          cache-from: build:${'BUILDKITE_S3_DEFAULT_REGION'}/build-cache:${REALLY_COOL_ENVIRONMENT}-build
           run: build
           volumes:
             - ./:/workspace
@@ -39,7 +39,7 @@ steps:
           run: terraform
           env:
             - ENVIRONMENT=staging
-            - TF_BACKEND_S3_REGION=${GLOBAL_TF_BACKEND_S3_REGION}
+            - TF_BACKEND_S3_REGION=${GLOBAL_TF_BACKEND_S3_EGIONs}
           volumes:
             - ./:/workspace
       - artifacts#v1.2.0:


### PR DESCRIPTION
* Added new rule allowing the user to check environment variables for quotes that would be included in the string.

Eg: It will provide a warning for the following: `REALLY_COOL_ENVIRONMENT: "super-cool-environment"` as the double quotes will end up included in the string.
This often happens when someone copy pastes the variable from another environment which will parse the quoting as expected.
It can be turned on and off in your config file with the value `NoQuotedEnvRule: boolean`

* Added a config file

This config file can be added to your .buildkite directory to turn specific rules on and off, as well as add in external environment variables that may be injected from outside your pipeline.